### PR TITLE
avante-nvim: reformat mkEnableOption and descriptions

### DIFF
--- a/modules/plugins/assistant/avante/avante-nvim.nix
+++ b/modules/plugins/assistant/avante/avante-nvim.nix
@@ -5,7 +5,7 @@
 in {
   options.vim.assistant = {
     avante-nvim = {
-      enable = mkEnableOption "complementary Neovim plugin for avante.nvim";
+      enable = mkEnableOption "Complementary Neovim plugin for avante.nvim";
       setupOpts = mkPluginSetupOption "avante-nvim" {
         provider = mkOption {
           type = nullOr str;
@@ -76,7 +76,7 @@ in {
         };
 
         dual_boost = {
-          enabled = mkEnableOption "dual_boost mode.";
+          enabled = mkEnableOption "Dual_boost mode.";
 
           first_provider = mkOption {
             type = str;
@@ -109,39 +109,39 @@ in {
 
         behaviour = {
           auto_suggestions =
-            mkEnableOption "auto suggestions.";
+            mkEnableOption "Auto suggestions.";
 
-          auto_set_highlight_group =
-            mkEnableOption "automatically set the highlight group for the current line."
-            // {
-              default = true;
-            };
+          auto_set_highlight_group = mkOption {
+            type = true;
+            default = true;
+            description = "Automatically set the highlight group for the current line.";
+          };
 
-          auto_set_keymaps =
-            mkEnableOption "automatically set the keymap for the current line."
-            // {
-              default = true;
-            };
+          auto_set_keymaps = mkOption {
+            type = bool;
+            default = true;
+            description = "Automatically set the keymap for the current line.";
+          };
 
           auto_apply_diff_after_generation =
-            mkEnableOption "automatically apply diff after LLM response.";
+            mkEnableOption "Automatically apply diff after LLM response.";
 
           support_paste_from_clipboard = mkEnableOption ''
-            pasting image from clipboard.
+            Pasting image from clipboard.
             This will be determined automatically based whether img-clip is available or not.
           '';
 
-          minimize_diff =
-            mkEnableOption "remove unchanged lines when applying a code block."
-            // {
-              default = true;
-            };
+          minimize_diff = mkOption {
+            type = bool;
+            default = true;
+            description = "Remove unchanged lines when applying a code block.";
+          };
 
-          enable_token_counting =
-            mkEnableOption "token counting."
-            // {
-              default = true;
-            };
+          enable_token_counting = mkOption {
+            type = bool;
+            default = true;
+            description = "Token counting.";
+          };
 
           enable_cursor_planning_mode =
             mkEnableOption "Cursor Planning Mode.";
@@ -188,14 +188,11 @@ in {
           };
         };
 
-        hints.enabled =
-          mkEnableOption ""
-          // {
-            default = true;
-            description = ''
-              Whether to enable hints.
-            '';
-          };
+        hints.enabled = mkOption {
+          type = bool;
+          default = true;
+          description = "Whether to enable hints.";
+        };
 
         windows = {
           position = mkOption {
@@ -204,14 +201,11 @@ in {
             description = "The position of the sidebar.";
           };
 
-          wrap =
-            mkEnableOption ""
-            // {
-              default = true;
-              description = ''
-                similar to vim.o.wrap.
-              '';
-            };
+          wrap = mkOption {
+            type = bool;
+            default = true;
+            description = "Similar to vim.o.wrap.";
+          };
 
           width = mkOption {
             type = int;
@@ -223,7 +217,7 @@ in {
             enabled = mkOption {
               type = bool;
               default = true;
-              description = "enable/disable the header.";
+              description = "Enable the sidebar header.";
             };
 
             align = mkOption {
@@ -235,7 +229,7 @@ in {
             rounded = mkOption {
               type = bool;
               default = true;
-              description = "Enable rounded sidebar header";
+              description = "Enable rounded sidebar header.";
             };
           };
 
@@ -249,9 +243,7 @@ in {
             height = mkOption {
               type = int;
               default = 8;
-              description = ''
-                Height of the input window in vertical layout.
-              '';
+              description = "Height of the input window in vertical layout.";
             };
           };
 
@@ -265,9 +257,7 @@ in {
             start_insert = mkOption {
               type = bool;
               default = true;
-              description = ''
-                Start insert mode when opening the edit window.
-              '';
+              description = "Start insert mode when opening the edit window.";
             };
           };
 
@@ -275,17 +265,13 @@ in {
             floating = mkOption {
               type = bool;
               default = false;
-              description = ''
-                Open the 'AvanteAsk' prompt in a floating window.
-              '';
+              description = "Open the 'AvanteAsk' prompt in a floating window.";
             };
 
             start_insert = mkOption {
               type = bool;
               default = true;
-              description = ''
-                Start insert mode when opening the ask window.
-              '';
+              description = "Start insert mode when opening the ask window.";
             };
 
             border = mkOption {
@@ -303,12 +289,11 @@ in {
         };
 
         diff = {
-          autojump =
-            mkEnableOption ""
-            // {
-              default = true;
-              description = "Automatically jumps to the next change.";
-            };
+          autojump = mkOption {
+            type = bool;
+            default = true;
+            description = "Automatically jumps to the next change.";
+          };
 
           override_timeoutlen = mkOption {
             type = int;

--- a/modules/plugins/assistant/avante/avante-nvim.nix
+++ b/modules/plugins/assistant/avante/avante-nvim.nix
@@ -112,7 +112,7 @@ in {
             mkEnableOption "Auto suggestions.";
 
           auto_set_highlight_group = mkOption {
-            type = true;
+            type = bool;
             default = true;
             description = "Automatically set the highlight group for the current line.";
           };


### PR DESCRIPTION
This PR aims to make formatting of avante.nvim more consistent. 
Adding dots do descriptions, fixing missed capitalization, transforming multiline string to one-liners, instead of merging `default = true;`, use mkOption.

I don't know if or how I should add it to changelog, because it doesn't affect the end user, but only future maintainers of said module. Per your request and suggestion, I would commit them too.
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
